### PR TITLE
P3-67(#23) feature/뉴스 api 백엔드 통신 연결 완료

### DIFF
--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_USER_URL,
+  baseURL: import.meta.env.VITE_API_DATA_URL,
   timeout: 5000,
   headers: { "Content-Type": "application/json" },
 });

--- a/src/api/newsApi.js
+++ b/src/api/newsApi.js
@@ -1,7 +1,7 @@
-// 뉴스 조회
 import api from "./axiosInstance";
-const news =()=>{
-    api.get("/news", { isAuthRequired: false });
+
+const news = async () => {
+    return await api.get("/news", { isAuthRequired: false });
 };
 
-export{ news };
+export { news };

--- a/src/pages/LandingPage/components/News.jsx
+++ b/src/pages/LandingPage/components/News.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState }  from "react";
-import DUMMY_NEWS from "./data/dummyNews";
+import React, { useEffect, useState } from "react";
 import { timeAgo } from "../../../utils/timeAgo";
-import { news } from "../../../api/newsApi"
+import { news } from "../../../api/newsApi";
 import { HiPlusCircle } from "react-icons/hi";
 
 const NEWS_SITE_URL = "https://www.bloomberg.com";
@@ -13,55 +12,70 @@ export default function News() {
         const fetchNews = async () => {
             try {
                 const response = await news(); // API 호출
-                setNewsData(response.data.data); // AIP 명세 형식 데이터 저장함
+                console.log("뉴스 응답:", response); // 응답 구조 확인
+    
+                // 응답이 정상적인지 확인 후 상태 업데이트
+                if (response && response.data && Array.isArray(response.data.data)) {
+                    console.log(response.data.data)
+                    setNewsData(response.data.data); // API 응답에서 'data' 배열을 저장
+                } else {
+                    console.error("잘못된 응답 구조:", response);
+                    setNewsData([]); // 에러 방지를 위해 빈 배열로 설정
+                }
             } catch (error) {
                 console.error("뉴스 데이터를 가져오는 중 오류 발생:", error);
+                setNewsData([]); // 에러 발생 시 빈 배열로 설정
             }
         };
-
+    
         fetchNews();
     }, []);
 
+    console.log("렌더링되는 뉴스 데이터:", newsData); // 데이터 확인용 로그
+
     return (
-        <div className="p-4">
+        <div className="w-full p-4">
             {/* 제목 */}
-            <h1 className="text-[18px] font-bold p-3">글로벌 경제 뉴스</h1>
-
-            {/* 컨테이너 */}
-            <div className="w-full overflow-x-auto "> {/* ✅ 가로 스크롤 적용 */}
-                <div className="flex space-x-4 p-3 rounded-lg min-w-max">
-                    {DUMMY_NEWS["Bloomberg"].slice(0, 10).map((article) => (
-                        <a key={article.news_id} href={article.news_url} target="_blank" rel="noopener noreferrer">
-                            <div className="bg-gray-50 p-3 rounded-lg shadow-md hover:shadow-lg transition-shadow min-w-[180px] sm:min-w-[220px] md:min-w-[260px] lg:min-w-[280px] max-w-[320px] flex flex-col duration-300">
-
-                                {/* 뉴스 이미지 */}
-                                <img
-                                    src={article.news_img}
+            <h1 className="text-[18px] font-bold ml-3">글로벌 경제 뉴스</h1>
+            {/* 데이터가 로딩되지 않았을 경우 표시 */}
+            {newsData.length === 0 ? (
+                <p className="text-gray-500 text-center">뉴스 데이터를 불러오는 중...</p>
+            ) : (
+                <div className="w-full overflow-auto"> {/* 가로 스크롤 적용 */}
+                    <div className="flex space-x-4 p-4 rounded-lg max-w-screen-xl">
+                        {newsData.slice(0, 10).map((article, index) => (
+                            <a key={index} href={article.news_url} target="_blank" rel="noopener noreferrer">
+                                <div className="bg-gray-50 p-3 rounded-lg shadow-md hover:shadow-lg transition-shadow min-w-[180px] sm:min-w-[220px] md:min-w-[260px] lg:min-w-[280px] max-w-[320px] flex flex-col duration-300 h-60">
+                                    {/* 뉴스 이미지 */}
+                                    <img
+                                    src={article.news_img.replace(/S\.jpg$/, "L.jpg")}
                                     alt={article.news_title}
-                                    className="w-full h-40 object-cover rounded-md"
-                                />
-                                {/* 뉴스 제목 */}
-                                <h2 className="mt-2 font-semibold text-sm">{article.news_title}</h2>
-                                {/* 출처 및 시간 ("00분 전" 표시) */}
-                                <p className="text-md text-gray-600">
-                                    {article.news_company} • {timeAgo(article.news_date)}
-                                </p>
-                            </div>
-                        </a>
-                    ))}
+                                    className="w-72 h-40 object-cover rounded-md"
+                                    />
 
-                    {/* 더보기 버튼 */}
-                    <a
-                        href={NEWS_SITE_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center justify-center min-w-[180px] sm:min-w-[220px] md:min-w-[260px] lg:min-w-[280px] max-w-[320px] bg-gray-50 text-blue-md font-bold text-lg rounded-lg shadow-md transition-all hover:bg-gray-200 duration-300"
-                    >
-                    <HiPlusCircle />
-            <span className="ml-1">more</span>
-                    </a>
+                                    {/* 뉴스 제목 */}
+                                    <h2 className="mt-2 font-semibold text-sm">{article.news_title}</h2>
+                                    {/* 출처 및 시간 ("00분 전" 표시) */}
+                                    <p className="text-md text-gray-600">
+                                        {article.news_company} • {timeAgo(article.news_date)}
+                                    </p>
+                                </div>
+                            </a>
+                        ))}
+
+                        {/* 더보기 버튼 */}
+                        <a
+                            href={NEWS_SITE_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center justify-center min-w-[180px] sm:min-w-[220px] md:min-w-[260px] lg:min-w-[280px] max-w-[320px] bg-gray-50 text-blue-md font-bold text-lg rounded-lg shadow-md transition-all hover:bg-gray-200 duration-300"
+                        >
+                            <HiPlusCircle />
+                            <span className="ml-1">more</span>
+                        </a>
+                    </div>
                 </div>
-            </div>
+            )}
         </div>
     );
 }

--- a/src/pages/LandingPage/index.jsx
+++ b/src/pages/LandingPage/index.jsx
@@ -16,7 +16,7 @@ export default function Index() {
       </div>
 
       {/** 해외 경제 뉴스 */}
-      <div className="mt-4">
+      <div className="flex flex-col w-full mt-4">
         <News />
       </div>
 


### PR DESCRIPTION
## PR Type
- [x] investing.com 뉴스 크롤링 데이터 GET 포스트맨 통신 Status:200 확인
- [x] REDIS 연결해서 크롤링 결과 확인
- [x] 뉴스 컴포넌트 배치 수정
- [x] 뉴스 컴포넌트 max 높이, 넓이 수정
- [x] url img 해상도 수정


## 해당 PR에 대한 설명
API 테스트 완료하여 프론트 단 연결해 놓았습니다. 랜딩페이지 너비에 맞춰 컴포넌트 배치했으며, 백엔드에서 불러온 url 형식을 수정해 이미지 해상도 조절 완료 했습니다. 실시간 기준으로 기획했지만, 많이 본 뉴스가 더 유익할 것으로 예상해 최근 뉴스 중 "가장 많이 본 뉴스" 크롤링으로 서비스 기획안 수정이 필요할 듯 합니다.
## 스크린샷
<img width="1354" alt="스크린샷 2025-02-27 오후 3 15 34" src="https://github.com/user-attachments/assets/e5ce5926-d332-468c-ba2d-90772f8a7242" />

## 기타 정보
