### PR TITLE
P3 86 feature/order details

### DIFF
--- a/src/pages/MyPage/components/Holdings.jsx
+++ b/src/pages/MyPage/components/Holdings.jsx
@@ -55,7 +55,7 @@ export default function Holdings() {
     <div>
       {/* 헤더 */}
       <div className="flex justify-between items-center">
-        <h1 className="text-lg font-bold">보유종목</h1>
+        <h1 className="text-lg font-bold ml-1 mt-3 mb-2.5">보유종목</h1>
 
         {/* 정렬 기준 드롭다운 */}
         <div className="relative">
@@ -89,7 +89,7 @@ export default function Holdings() {
       {/* 보유 종목 리스트 */}
       <div className="bg-gray-light p-4 mt-1 rounded-xl">
       {sortedHoldings.map((stock) => (
-        <div key={stock.id} className="bg-white p-4 ml-1 mr-1 mt-2 mb-3 rounded-xl">
+        <div key={stock.id} className="bg-white p-4 mb-2 rounded-xl">
           {/* 종목명 & 수익금액 */}
           <div className="flex justify-between items-center border-b pb-2">
             <div>

--- a/src/pages/MyPage/components/OrderDetails.jsx
+++ b/src/pages/MyPage/components/OrderDetails.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+
+const DUMMY_ORDERS = [
+  {
+    date: "2025.02.28",
+    ticker: "NVIDIA",
+    orderType: "현금매수",
+    orderPrice: "130.00",
+    orderAmount: "40",
+    executedPrice: "-",
+    executedAmount: "-",
+    unexecutedAmount: "40",
+    status: "미체결",
+    orderNumber: "232424",
+  },
+  {
+    date: "2025.02.28",
+    ticker: "NVIDIA",
+    orderType: "현금매도",
+    orderPrice: "134.00",
+    orderAmount: "10",
+    executedPrice: "134.00",
+    executedAmount: "10",
+    unexecutedAmount: "-",
+    status: "체결 완료",
+    orderNumber: "232423",
+  }
+];
+
+export default function OrderDetails() {
+  const [activeTab, setActiveTab] = useState("전체"); // 기본값: 전체
+
+  // 필터링된 주문 데이터
+  const filteredOrders = DUMMY_ORDERS.filter(order => {
+    if (activeTab === "전체") return true;
+    return order.status === activeTab;
+  });
+
+  return (
+    <div className="bg-gray-light p-4 mt-2.5 rounded-xl">
+     {/* 탭 메뉴 */}
+     <div className="flex gap-1 text-[14px] ">
+        {["전체", "체결 완료", "미체결"].map(tab => (
+          <p
+            key={tab}
+            className={`cursor-pointer ${
+              activeTab === tab ? "font-semibold min-w-12 text-center bg-blue-md px-2 py-1 text-white rounded" : "text-gray-500 min-w-12 text-center px-2 py-1"
+            }`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab === "체결 완료" ? "체결" : tab} {/* UI에는 "체결"로 표시 */}
+          </p>
+        ))}
+      </div>
+      
+
+      {/* 주문 내역 테이블 */}
+      <div className="bg-white p-2 rounded-xl mt-3">
+        <table className="w-full border-collapse text-center text-sm">
+          <thead>
+            <tr className="border-b border-blue-md font-semibold bg-white">
+              <th className="p-2">종목명<br />매매구분</th>
+              <th className="p-2">주문단가<br />주문수량</th>
+              <th className="p-2">체결단가<br />체결수량</th>
+              <th className="p-2">상태<br />미체결수량</th>
+              <th className="p-2">주문번호<br />주문일자</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredOrders.map((order, index) => (
+              <tr key={index} className="border-b border-gray-200">
+                <td className="p-2">
+                  <span className="font-semibold">{order.ticker}</span> <br />
+                  {order.orderType}
+                </td>
+                <td className="p-2">
+                  {order.orderPrice} <br />
+                  {order.orderAmount}
+                </td>
+                <td className="p-2">
+                  {order.executedPrice} <br />
+                  {order.executedAmount}
+                </td>
+                <td className="p-2">
+                  {order.status}<br />
+                  {order.unexecutedAmount} 
+                </td>
+                <td className="p-2">
+                  {order.orderNumber} <br />
+                  {order.date}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyPage/components/StockBalance.jsx
+++ b/src/pages/MyPage/components/StockBalance.jsx
@@ -1,7 +1,20 @@
 import React, { useState } from "react";
 
 export default function StockBalance() {
-  const [currency, setCurrency] = useState("원화"); // 환율 단위 상태 (기본 원화)
+  const [currency, setCurrency] = useState("원화"); // 환율 단위 상태
+
+  // ✅ 더미 데이터 (기본값)
+  const dummyData = {
+    evaluationAmount: 28500,
+    profitLossChange: 1500,
+    profitRate: 5.56,
+    purchaseAmount: 27000,
+    tradeProfitLoss: 1200,
+    exchangeProfitLoss: 300
+  };
+
+  // ✅ 값에 따라 색상 결정하는 함수
+  const getColorClass = (value) => (value >= 0 ? "text-red-500" : "text-blue-500");
 
   return (
     <div>
@@ -30,16 +43,29 @@ export default function StockBalance() {
       <div className="bg-gray-light p-4 rounded-lg flex justify-between">
         {/* 평가 금액 */}
         <div>
-          <p className="font-bold">평가금액</p>
-          <p className="text-lg font-bold">28,500 원</p>
-          <p className="text-sm">▲ 손익등락(수익률)</p>
+          <p className="text-lg font-bold">평가금액</p>
+          <p className={`text-2xl font-bold ${getColorClass(dummyData.evaluationAmount)}`}>
+            {dummyData.evaluationAmount.toLocaleString()} 원
+          </p>
+          <p className={`text-sm ${getColorClass(dummyData.profitLossChange)}`}>
+            ▲ {dummyData.profitLossChange.toLocaleString()} ({dummyData.profitRate.toFixed(2)}%)
+          </p>
         </div>
 
         {/* 추가 정보 */}
-        <div className="text-right space-y-1">
-          <p className="font-bold">매수금액</p>
-          <p className="font-bold">매매손익</p>
-          <p className="font-bold">환차손익</p>
+        <div className="text-sm text-right min-w-[220px] mr-3 justify-center flex flex-col items-end">
+          <p className="font-semibold w-full flex justify-between">
+            <span className="text-gray-500">매수금액</span> 
+            <span>{dummyData.purchaseAmount.toLocaleString()} 원</span>
+          </p>
+          <p className={`font-bold w-full flex justify-between ${getColorClass(dummyData.tradeProfitLoss)}`}>
+            <span className="text-gray-500">매매손익</span> 
+            <span>{dummyData.tradeProfitLoss.toLocaleString()} 원</span>
+          </p>
+          <p className={`font-bold w-full flex justify-between ${getColorClass(dummyData.exchangeProfitLoss)}`}>
+            <span className="text-gray-500">환차손익</span> 
+            <span>{dummyData.exchangeProfitLoss.toLocaleString()} 원</span>
+          </p>
         </div>
       </div>
     </div>

--- a/src/pages/MyPage/components/TradeDetails.jsx
+++ b/src/pages/MyPage/components/TradeDetails.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-
+import React, { useState } from "react";
+import OrderDetails from "./OrderDetails";
 
 const DUMMY_TRADES = [
   {
@@ -65,36 +65,63 @@ const DUMMY_TRADES = [
 ];
 
 export default function TradeDetails() {
+  const [activeTab, setActiveTab] = useState("profit");
+  const getColorClass = (value) => (value >= 0 ? "text-red-500 font-semibold" : "text-blue-500 font-semibold");
   return (
     <div className="mt-1 rounded-xl">
-    {/* 제목 */}
-    <div className="text-lg font-bold flex gap-4">
-      <p className="cursor-pointer">손익 내역</p>
-      <p className="cursor-pointer">주문 내역</p>
-    </div>
+    {/* 탭 메뉴 */}
+    <div className="flex border-b border-gray-300 text-[16px]">
+        <button
+          className={`p-2 w-1/4 text-center ${
+            activeTab === "profit" ? "border-b-2 border-blue-md font-bold" : "text-gray-500"
+          }`}
+          onClick={() => setActiveTab("profit")}
+        >
+          손익 내역
+        </button>
+        <button
+          className={`p-2 w-1/4 text-center ${
+            activeTab === "order" ? "border-b-2 border-blue-md font-bold" : "text-gray-500"
+          }`}
+          onClick={() => setActiveTab("order")}
+        >
+          주문 내역
+        </button>
+      </div>
   
-  
-      <div className="bg-gray-light p-4 mt-1 rounded-xl">
-      
-        {/* 요약 정보 */}
-        <div className="grid grid-cols-4 gap-2 p-2 text-[14px]">
-          <p className="font-semibold">실현 손익 (USD)</p>
+      {activeTab === "profit" ? (
+        <div className="bg-gray-light p-4 mt-2.5 rounded-xl">
           
-            {DUMMY_TRADES.reduce((acc, trade) => acc + parseFloat(trade.profit), 0).toFixed(2)}
-          
-          <p className="font-semibold">매도 금액 (USD)</p>
-          <p>
-            {DUMMY_TRADES.reduce((acc, trade) => acc + parseFloat(trade.sellPrice) * parseInt(trade.sellAmount), 0).toFixed(2)}
-          </p>
-          <p className="font-semibold">매매 손익 (USD)</p>
-          <p>
-            {DUMMY_TRADES.reduce((acc, trade) => acc + ((parseFloat(trade.sellPrice) - parseFloat(trade.buyPrice)) * parseInt(trade.sellAmount)), 0).toFixed(2)}
-          </p>
-          <p className="font-semibold">환차 손익 (KRW)</p>
-          <p>
-            {DUMMY_TRADES.reduce((acc, trade) => acc + ((parseFloat(trade.sellExchangeRate) - parseFloat(trade.buyExchangeRate)) * parseFloat(trade.sellPrice) * parseInt(trade.sellAmount)), 0).toFixed(2)}
-          </p>
-        </div>
+          {/* ✅ 값에 따라 색상 결정하는 함수 */}
+    
+
+{/* 요약 정보 */}
+<div className="grid grid-cols-4 gap-2 p-2 text-[14px]">
+  <p className="font-semibold text-gray-500">실현 손익</p>
+  <p className={`${getColorClass(DUMMY_TRADES.reduce((acc, trade) => acc + parseFloat(trade.profit), 0))}`}>
+    {DUMMY_TRADES.reduce((acc, trade) => acc + parseFloat(trade.profit), 0).toFixed(2)}
+    <span> USD</span>
+  </p>
+
+  <p className="font-semibold text-gray-500">매도 금액</p>
+  <p className={`${getColorClass(DUMMY_TRADES.reduce((acc, trade) => acc + parseFloat(trade.sellPrice) * parseInt(trade.sellAmount), 0))}`}>
+    {DUMMY_TRADES.reduce((acc, trade) => acc + parseFloat(trade.sellPrice) * parseInt(trade.sellAmount), 0).toFixed(2)}
+    <span> USD</span>
+  </p>
+
+  <p className="font-semibold text-gray-500">매매 손익</p>
+  <p className={`${getColorClass(DUMMY_TRADES.reduce((acc, trade) => acc + ((parseFloat(trade.sellPrice) - parseFloat(trade.buyPrice)) * parseInt(trade.sellAmount)), 0))}`}>
+    {DUMMY_TRADES.reduce((acc, trade) => acc + ((parseFloat(trade.sellPrice) - parseFloat(trade.buyPrice)) * parseInt(trade.sellAmount)), 0).toFixed(2)}
+    <span> USD</span>
+  </p>
+
+  <p className="font-semibold text-gray-500">환차 손익</p>
+  <p className={`${getColorClass(DUMMY_TRADES.reduce((acc, trade) => acc + ((parseFloat(trade.sellExchangeRate) - parseFloat(trade.buyExchangeRate)) * parseFloat(trade.sellPrice) * parseInt(trade.sellAmount)), 0))}`}>
+    {DUMMY_TRADES.reduce((acc, trade) => acc + ((parseFloat(trade.sellExchangeRate) - parseFloat(trade.buyExchangeRate)) * parseFloat(trade.sellPrice) * parseInt(trade.sellAmount)), 0).toFixed(2)}
+    <span> KRW</span>
+  </p>
+</div>
+
 
         {/* 매매 내역 테이블 */}
         <div className="bg-white p-2 mt-3 rounded-xl">
@@ -102,12 +129,12 @@ export default function TradeDetails() {
             <thead>
               <tr className="border-b border-blue-300 font-semibold bg-white">
                 <th className="p-2">매도일자</th>
-                <th className="p-2">종목명 <br/>ticker</th>
-                <th className="p-2">실현손익(USD) <br/> 손익률(%)</th>
-                <th className="p-2">매도 평균가(USD) <br/> 매수 평균가(USD)</th>
-                <th className="p-2">매도 금액(USD) <br/> 매수 금액(USD)</th>
+                <th className="p-2">종목명</th>
+                <th className="p-2">실현손익 <br/> 손익률 (%)</th>
+                <th className="p-2">매도 평균가 <br/> 매수 평균가</th>
+                <th className="p-2">매도 금액 <br/> 매수 금액</th>
                 <th className="p-2">매도 수량 <br/> 매수 수량</th>
-                <th className="p-2">매도 환율(KRW/USD) <br/> 매수 환율(KRW/USD)</th>
+                <th className="p-2">매도 환율 (KRW/USD) <br/> 매수 환율 (KRW/USD)</th>
               </tr>
             </thead>
             
@@ -144,7 +171,13 @@ export default function TradeDetails() {
             </tbody>
           </table>
         </div>
-      </div>
+        </div>
+      ) : (
+        <OrderDetails />
+      )}
+      
+      
+        
     </div>
   );
 }


### PR DESCRIPTION
## PR Type
- [x] 손익내역 옆에 주문 내역 탭 만들기
- [x] 주문내역 컴포넌트 생성해서 UI 구성하기
- [x] 보유종목 더 UI 디테일 수정하기
- [x] 해외 주식 잔고 ui 수정 및 값에 따라 색깔 변환
- [x] 해외 주식 잔고 api 함수 추가

## 해당 PR에 대한 설명
My 계좌 내 OrderDetails.jsx를 추가하면서 My계좌 페이지를 전면 수정했습니다. css 업데이트를 진행했고, UX관점에서 더욱 HTS스럽게 숫자 컬러 수정, 텍스트 크기 조절, 각 컴포넌트 별 margin, padding 추가로 간격 조절을 진행했습니다.
## 스크린샷
<img width="670" alt="스크린샷 2025-02-28 오후 5 33 39" src="https://github.com/user-attachments/assets/0787ca91-1627-45a3-b359-7722fb54d881" />
<img width="676" alt="스크린샷 2025-02-28 오후 5 34 11" src="https://github.com/user-attachments/assets/44e874e0-2fad-4a2a-a493-af5ff51364d1" />
<img width="1358" alt="스크린샷 2025-02-28 오후 5 33 50" src="https://github.com/user-attachments/assets/63a0382a-5e35-423a-a305-93f1cce73a18" />

## 기타 정보
페이지 간의 디자인 및 컴포넌트 크기 조정는 계속 업데이트 될 예정입니다.
