### PR TITLE
P3-98(#52) feature/실적발표 페이지 UI 구현

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -14,7 +14,7 @@ export default function Layout() {
         </header>
 
         {/* 메인 콘텐츠 */}
-        <main className="flex flex-grow min-h-screen pt-16 items-center justify-center">
+        <main className="flex flex-grow pt-16 items-center justify-center">
           <Outlet />
         </main>
 

--- a/src/pages/EarningsPage/components/CompanyInfo.jsx
+++ b/src/pages/EarningsPage/components/CompanyInfo.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import earningdata from "./earningdata";
+
+const CompanyInfo = () => {
+  const { ticker } = useParams(); // URL에서 ticker 가져오기
+
+  if (!ticker) {
+    return <p className="text-red-500">티커 정보를 찾을 수 없습니다.</p>;
+  }
+
+  // 현재 날짜 기준 가장 최근 실적 발표 데이터 찾기
+  const today = new Date();
+  const pastReports = earningdata.filter((data) => new Date(data.date) <= today);
+  const latestReport = pastReports.sort((a, b) => new Date(b.date) - new Date(a.date))[0];
+
+  // 변동률(%) 계산 함수
+  const calculatePercentageChange = (actual, estimated) => {
+    if (!actual || !estimated) return null;
+    return (((actual - estimated) / estimated) * 100).toFixed(2);
+  };
+
+  // 스타일 결정 함수
+  const getTextColor = (value) => {
+    if (value > 0) return "text-red-500"; // 양수 → 빨간색
+    if (value < 0) return "text-blue-500"; // 음수 → 파란색
+    return "text-gray-700"; // 기본색
+  };
+
+  const epsChange = latestReport
+    ? calculatePercentageChange(parseFloat(latestReport.eps), parseFloat(latestReport.eps_estimated))
+    : null;
+
+  const revenueChange = latestReport
+    ? calculatePercentageChange(parseInt(latestReport.revenue), parseInt(latestReport.revenue_estimated))
+    : null;
+
+  const formatToBillionWon = (amount) => {
+    return amount ? (parseInt(amount) / 1_0000_0000).toFixed(2) + "억원" : "N/A";
+  };
+
+  return (
+    <div className="flex bg-gray-light p-2 rounded-lg items-center space-x-50 w-full h-full px-40">
+      
+
+
+      {/* 기업 로고 */}
+      <img
+        src={`${import.meta.env.VITE_STOCK_LOGO_URL}${ticker}.png`}
+        alt={`${ticker} 로고`}
+        className="w-8 h-8 object-contain"
+      />
+
+      {/* 기업명 */}
+      <h2 className="text-lg font-semibold">{ticker}</h2>
+
+      {/* EPS 정보 */}
+      {latestReport && (
+        <div className="flex items-center space-x-1">
+          <span className="font-semibold">EPS:</span>
+          <span>{latestReport.eps ?? "N/A"}</span>
+          {epsChange !== null && (
+            <span className={`${getTextColor(epsChange)} text-sm`}>
+              ({epsChange}%)
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* 매출 정보 */}
+      {latestReport && (
+        <div className="flex items-center space-x-1">
+          <span className="font-semibold">매출:</span>
+          <span>{formatToBillionWon(latestReport.revenue)}</span>
+          {revenueChange !== null && (
+            <span className={`${getTextColor(revenueChange)} text-sm`}>
+              ({revenueChange}%)
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CompanyInfo;

--- a/src/pages/EarningsPage/components/EarningsChart.jsx
+++ b/src/pages/EarningsPage/components/EarningsChart.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Line, ComposedChart } from "recharts";
+import earningdata from "./earningdata";
+
+const EarningsChart = () => {
+  // 데이터 변환 (EPS 및 매출 변동률 추가)
+  const chartData = earningdata.map((data) => {
+    const eps = data.eps ? parseFloat(data.eps) : null;
+    const eps_estimated = data.eps_estimated ? parseFloat(data.eps_estimated) : null;
+    const revenue = data.revenue ? parseFloat(data.revenue) : null;
+    const revenue_estimated = data.revenue_estimated ? parseFloat(data.revenue_estimated) : null;
+
+    // 변동률 계산 (eps, revenue가 null이면 표시 안 함)
+    const eps_variation = eps && eps_estimated ? (((eps - eps_estimated) / eps_estimated) * 100).toFixed(2) : null;
+    const revenue_variation = revenue && revenue_estimated ? (((revenue - revenue_estimated) / revenue_estimated) * 100).toFixed(2) : null;
+
+    return {
+      date: data.date,
+      eps_estimated,
+      eps,
+      "EPS 예측 오차값": eps_variation ? parseFloat(eps_variation) : null,
+      revenue_estimated,
+      revenue,
+      "매출 예측 오차값": revenue_variation ? parseFloat(revenue_variation) : null,
+    };
+  });
+
+  return (
+    <div className="flex p-4 w-full max-w-7xl">
+
+      
+      
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+          <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+          <YAxis yAxisId="left" tick={{ fontSize: 12 }} />
+          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} domain={[-20, 20]} />
+          <Tooltip />
+          <Legend />
+
+          {/* EPS 바 차트 */}
+          <Bar yAxisId="left" dataKey="eps_estimated" fill="#ccc" name="예상 EPS" />
+          <Bar yAxisId="left" dataKey="eps" fill="#32cd32" name="실제 EPS" />
+
+          {/* EPS 변동률 선 그래프 */}
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="EPS 예측 오차값"
+            stroke="#ff7300"
+            strokeWidth={2}
+            dot={true}
+            name="EPS 예측 오차값"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+      
+      
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+          <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+          <YAxis yAxisId="left" tick={{ fontSize: 12 }} />
+          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} domain={[-20, 20]} />
+          <Tooltip />
+          <Legend />
+
+          {/* 매출 바 차트 */}
+          <Bar yAxisId="left" dataKey="revenue_estimated" fill="#ccc" name="예상 매출" />
+          <Bar yAxisId="left" dataKey="revenue" fill="#7b68ee" name="실제 매출" />
+
+          {/* 매출 변동률 그래프 */}
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="매출 예측 오차값"
+            stroke="#ff7300"
+            strokeWidth={2}
+            dot={true}
+            name="매출 예측 오차값"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default EarningsChart;

--- a/src/pages/EarningsPage/components/EarningsReport.jsx
+++ b/src/pages/EarningsPage/components/EarningsReport.jsx
@@ -1,0 +1,125 @@
+import React from "react";
+import earningdata from "./earningdata";
+
+const EarningsReport = () => {
+  if (!earningdata || earningdata.length === 0) return <p>데이터가 없습니다.</p>;
+
+  // 현재 날짜 기준으로 과거/미래 데이터 분류
+  const today = new Date();
+
+  // 가장 최근 발표된 실적 데이터 찾기
+  const pastReports = earningdata.filter((data) => new Date(data.date) <= today);
+  const latestReport = pastReports.sort((a, b) => new Date(b.date) - new Date(a.date))[0];
+
+  // 다가올 실적 발표 데이터 찾기
+  const upcomingReports = earningdata.filter((data) => new Date(data.date) > today);
+  const nextReport = upcomingReports.sort((a, b) => new Date(a.date) - new Date(b.date))[0];
+
+  // 변동률(%) 계산
+  const calculatePercentageChange = (actual, estimated) => {
+    if (!actual || !estimated) return null;
+    return (((actual - estimated) / estimated) * 100).toFixed(2);
+  };
+
+  
+  const getTextColor = (value) => {
+    if (value > 0) return "text-red-500";
+    if (value < 0) return "text-blue-500";
+    return "text-gray-700";
+  };
+
+  const formatToBillionWon = (amount) => {
+    return amount ? (parseInt(amount) / 1_0000_0000).toFixed(2) + "억원" : "N/A";
+  };
+
+  // amc, bmo 변환
+  const formatTime = (time) => {
+    return time === "amc" ? "폐장후" : time === "bmo" ? "개장전" : time;
+  };
+
+  return (
+    <div>
+    <div className="bg-gray-light mb-5 flex gap-10 justify-center p-8 rounded-lg">
+      {/* 가장 최근 발표된 실적 데이터 */}
+      {latestReport && (
+        <div className="mb-6">
+          <h2 className="font-bold text-[16px] mb-3">가장 최근 실적 발표</h2>
+          <div className="bg-white w-lg p-8 rounded-md shadow-md text-sm">
+            <div className="flex justify-between mb-2">
+              <span className="font-semibold">실적 발표일</span>
+              <span>{latestReport.date.replace(/-/g, "년 ") + "일"}</span>
+            </div>
+            <div className="flex justify-between mb-2">
+              <span className="font-semibold">발표 시간</span>
+              <span>{formatTime(latestReport.time)}</span>
+            </div>
+            <div className="flex justify-between mb-2">
+              <span className="font-semibold">예상 EPS</span>
+              <span>{latestReport.eps_estimated}</span>
+            </div>
+            <div className="flex justify-between mb-2">
+              <span className="font-semibold">실제 EPS</span>
+              <span>
+                {latestReport.eps ?? "N/A"}{" "}
+                {latestReport.eps && (
+                  <span className={`${getTextColor(calculatePercentageChange(parseFloat(latestReport.eps), parseFloat(latestReport.eps_estimated)))} text-sm`}>
+                    ({calculatePercentageChange(parseFloat(latestReport.eps), parseFloat(latestReport.eps_estimated))}%)
+                  </span>
+                )}
+              </span>
+            </div>
+            <div className="flex justify-between mb-2">
+              <span className="font-semibold">예상 매출</span>
+              <span>{formatToBillionWon(latestReport.revenue_estimated)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-semibold">실제 매출</span>
+              <span>
+                {formatToBillionWon(latestReport.revenue) ?? "N/A"}{" "}
+                {latestReport.revenue && (
+                  <span className={`${getTextColor(calculatePercentageChange(parseInt(latestReport.revenue), parseInt(latestReport.revenue_estimated)))} text-sm`}>
+                    ({calculatePercentageChange(parseInt(latestReport.revenue), parseInt(latestReport.revenue_estimated))}%)
+                  </span>
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    
+    
+      {/* 다가올 실적 발표 데이터 */}
+      {nextReport && (
+        <div>
+          <h2 className="font-bold text-[16px] mb-3">다가올 실적 발표</h2>
+          <div className="bg-white w-lg p-8 rounded-md shadow-md text-sm">
+            <div className="flex justify-between mb-3">
+              <span className="font-semibold">실적 발표 예정일</span>
+              <span>{nextReport.date.replace(/-/g, "년 ") + "일"}</span>
+            </div>
+            <div className="flex justify-between mb-4">
+              <span className="font-semibold">예상 EPS</span>
+              <span>{nextReport.eps_estimated}</span>
+            </div>
+            <div className="flex justify-between mb-4">
+              <span className="font-semibold">실제 EPS</span>
+              <span className="text-gray-400">발표 예정</span>
+            </div>
+            <div className="flex justify-between mb-4">
+              <span className="font-semibold">예상 매출</span>
+              <span>{formatToBillionWon(nextReport.revenue_estimated)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-semibold">실제 매출</span>
+              <span className="text-gray-400">발표 예정</span>
+            </div>
+          </div>
+        
+          </div>
+      )}
+    </div>
+    </div>
+  );
+};
+
+export default EarningsReport;

--- a/src/pages/EarningsPage/components/earningdata.js
+++ b/src/pages/EarningsPage/components/earningdata.js
@@ -1,0 +1,45 @@
+const earningdata = [
+    {
+      date: "2024-04-23",
+      eps: "0.45",
+      eps_estimated: "0.51",
+      revenue: "21301000000",
+      revenue_estimated: "22220029354",
+      time: "amc",
+    },
+    {
+      date: "2024-07-23",
+      eps: "0.52",
+      eps_estimated: "0.62",
+      revenue: "25500000000",
+      revenue_estimated: "24539747788",
+      time: "amc",
+    },
+    {
+      date: "2024-10-23",
+      eps: "0.72",
+      eps_estimated: "0.58",
+      revenue: "25182000000",
+      revenue_estimated: "25468371161",
+      time: "amc",
+    },
+    {
+      date: "2025-01-29",
+      eps: "0.73",
+      eps_estimated: "0.774",
+      revenue: "25707000000",
+      revenue_estimated: "27258924570",
+      time: "amc",
+    },
+    {
+      date: "2025-04-22",
+      eps: null, // null 값 유지
+      eps_estimated: "0.59",
+      revenue: null, // null 값 유지
+      revenue_estimated: "23972905560",
+      time: "bmo",
+    },
+  ];
+  
+  export default earningdata;
+  

--- a/src/pages/EarningsPage/index.jsx
+++ b/src/pages/EarningsPage/index.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import CompanyInfo from "./components/CompanyInfo";
+import EarningsReport from "./components/EarningsReport";
+import EarningsChart from "./components/EarningsChart";
+
+const EarningsPage = () => {
+  return (
+    
+    <div className="p-4">
+      <div className="flex justify-between text-lg font-bold">
+        <h1>실적 발표 및 어닝콜 정보</h1>
+        </div>
+      <h2 className="text-blue-md mt-2 mb-4 font-semibold">기업의 실적 발표 일정을 한눈에 확인하고, 예상 EPS 및 매출과 실제 실적을 비교해보세요. </h2>
+      {/* 기업 정보 */}
+      <div className="flex rounded-lg mb-5  mt-3">
+        <CompanyInfo />
+      </div>
+
+      <div>
+        {/* 실적 발표 정보 */}
+        <div>
+          <EarningsReport />
+        </div>
+
+        {/* 차트 */}
+        <h2 className="text-blue-md mt-2 mb-4 font-semibold">EPS 및 매출 변동 추이를 확인하고, 투자 결정을 위한 필수 정보를 쉽고 빠르게 확인하세요!</h2>
+        <div className=" bg-gray-light flex-col mb-10 rounded-lg justify-center">
+        <div className=" p-4 grid-cols-2 grid">
+        <h2 className="text-sm font-bold">분기별 EPS 변동 추이</h2>
+        <h2 className="text-sm font-bold">분기별 매출 변동 추이</h2>
+        </div>
+          <EarningsChart />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EarningsPage;

--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -10,6 +10,7 @@ import DisclosureListPage from "../pages/DisclosureListPage/DisclosureListPage";
 import DisclosureDetailPage from "../pages/DisclosureDetailPage";
 import MainPage from "../pages/MainPage";
 import IntroduceDisclosurePage from "../pages/IntroduceDisclosurePage";
+import EarningsPage from "../pages/EarningsPage";
 
 const router = createBrowserRouter([
   {
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
       { path: "/my_page", element: <MyPage /> },
       { path: "/stocks", element: <StockListPage /> },
       { path: "/disclosures", element: <DisclosureListPage /> },
+      { path: "/earnings/:ticker", element: <EarningsPage /> },
       {
         path: "/disclosures/:filling_id",
         element: <DisclosureDetailPage />,


### PR DESCRIPTION
## PR Type
-[] EarningsReport.jsx에서 가장 최근 실적 데이터를 자동으로 가져오도록 수정
-[] EarningsReport.jsx에서 EPS 및 매출 변동률(%) 계산 및 표시 기능 추가
양수(빨간색), 음수(파란색) 강조
-[] EarningsReport.jsx에서 미래 실적 발표 데이터를 포함하도록 수정
EPS, 매출이 null일 경우 "발표 예정"으로 표시
-[] CompanyInfo.jsx에서 기업 정보(티커, 로고) 및 최근 실적 데이터 표시
http://localhost:19099/v1/api/earnings/{ticker} 경로에서 티커 가져오기
기업 로고 표시 (VITE_STOCK_LOGO_URL + ticker + ".png")
가장 최근 실적 데이터 가져와 EPS, 매출 및 변동률 표시
한 줄 리스트 형태(로고 / 기업명 / EPS(변동률) / 매출(변동률))로 배치
-[]  EarningsChart.jsx에서 SimpleBarChart를 활용하여 EPS 차트 추가
earningdata.js에서 date, eps, eps_estimated 데이터를 가져와 차트 구성
EPS 변동률(%)을 계산하여 차트 위에 표시
-[] EarningsChart.jsx에서 EPS 변동률을 점(Scatter) 대신 선(LineChart)으로 표시하도록 변경
-[]  EarningsChart.jsx에서 EPS 변동률이 양수(빨간색 #ff7300), 음수(청록색 #20b2aa)로 렌더링되도록 수정

-[]  EarningsChart.jsx에서 매출 차트를 추가하여 EPS 차트 아래에 배치
earningdata.js에서 date, revenue, revenue_estimated 데이터를 가져와 차트 구성
매출 변동률(%)을 계산하여 EPS 차트와 동일한 방식으로 표시
-[]  실적 발표 정보(EarningsReport.jsx)와 차트(EarningsChart.jsx)를 위아래 배치하도록 CSS 수정
flex flex-col space-y-6을 사용하여 UI 정리
차트 배경을 bg-gray-100로 통일하여 가독성 개선

## 해당 PR에 대한 설명
이번 PR에서는 실적 발표 페이지의 UI 개선 및 데이터 시각화 기능 추가를 진행했습니다.
api 연동과 css 업데이트는 이어서 진행할 예정입니다.
## 스크린샷
<img width="841" alt="스크린샷 2025-03-06 오후 3 53 58" src="https://github.com/user-attachments/assets/a6f41e82-3f08-48f3-b300-264175a3d98e" />

